### PR TITLE
Lazy implementqtion of bytestringsToVectors

### DIFF
--- a/src/HaskellWorks/Data/Vector/AsVector64.hs
+++ b/src/HaskellWorks/Data/Vector/AsVector64.hs
@@ -3,8 +3,10 @@ module HaskellWorks.Data.Vector.AsVector64
   ( AsVector64(..)
   ) where
 
+import Data.Bits
 import Data.Word
 
+import qualified Data.ByteString      as BS
 import qualified Data.Vector.Storable as DVS
 
 class AsVector64 a where
@@ -12,3 +14,42 @@ class AsVector64 a where
 
 instance AsVector64 (DVS.Vector Word64) where
   asVector64 = id
+
+instance AsVector64 BS.ByteString where
+  asVector64 bs = DVS.constructN ((BS.length bs + 7) `div` 8) go
+    where go :: DVS.Vector Word64 -> Word64
+          go u = let bsi = DVS.length u * 8 in
+            if bsi + 8 <= BS.length bs
+              then  let w0 = fromIntegral $ BS.index bs (bsi + 0)
+                        w1 = fromIntegral $ BS.index bs (bsi + 1)
+                        w2 = fromIntegral $ BS.index bs (bsi + 2)
+                        w3 = fromIntegral $ BS.index bs (bsi + 3)
+                        w4 = fromIntegral $ BS.index bs (bsi + 4)
+                        w5 = fromIntegral $ BS.index bs (bsi + 5)
+                        w6 = fromIntegral $ BS.index bs (bsi + 6)
+                        w7 = fromIntegral $ BS.index bs (bsi + 7)
+                    in  (w0 `shiftL`  0) .|.
+                        (w1 `shiftL`  8) .|.
+                        (w2 `shiftL` 16) .|.
+                        (w3 `shiftL` 24) .|.
+                        (w4 `shiftL` 32) .|.
+                        (w5 `shiftL` 40) .|.
+                        (w6 `shiftL` 48) .|.
+                        (w7 `shiftL` 56)
+              else  let w0 = let i = bsi + 0 in if i < BS.length bs then fromIntegral $ BS.index bs (bsi + 0) else 0
+                        w1 = let i = bsi + 1 in if i < BS.length bs then fromIntegral $ BS.index bs (bsi + 1) else 0
+                        w2 = let i = bsi + 2 in if i < BS.length bs then fromIntegral $ BS.index bs (bsi + 2) else 0
+                        w3 = let i = bsi + 3 in if i < BS.length bs then fromIntegral $ BS.index bs (bsi + 3) else 0
+                        w4 = let i = bsi + 4 in if i < BS.length bs then fromIntegral $ BS.index bs (bsi + 4) else 0
+                        w5 = let i = bsi + 5 in if i < BS.length bs then fromIntegral $ BS.index bs (bsi + 5) else 0
+                        w6 = let i = bsi + 6 in if i < BS.length bs then fromIntegral $ BS.index bs (bsi + 6) else 0
+                        w7 = let i = bsi + 7 in if i < BS.length bs then fromIntegral $ BS.index bs (bsi + 7) else 0
+                    in  (w0 `shiftL`  0) .|.
+                        (w1 `shiftL`  8) .|.
+                        (w2 `shiftL` 16) .|.
+                        (w3 `shiftL` 24) .|.
+                        (w4 `shiftL` 32) .|.
+                        (w5 `shiftL` 40) .|.
+                        (w6 `shiftL` 48) .|.
+                        (w7 `shiftL` 56)
+

--- a/test/HaskellWorks/Data/Vector/AsVector64sSpec.hs
+++ b/test/HaskellWorks/Data/Vector/AsVector64sSpec.hs
@@ -6,6 +6,7 @@ module HaskellWorks.Data.Vector.AsVector64sSpec
   ( spec
   ) where
 
+import HaskellWorks.Data.Vector.AsVector64
 import HaskellWorks.Data.Vector.AsVector64s
 import HaskellWorks.Hspec.Hedgehog
 import Hedgehog
@@ -20,7 +21,7 @@ import qualified Hedgehog.Range       as R
 
 spec :: Spec
 spec = describe "HaskellWorks.Data.Vector.AsVector64sSpec" $ do
-  it "Conversion of ByteString works" $ requireProperty $ do
+  it "Conversion of ByteString works 1" $ requireProperty $ do
     bss <- forAll $ (BS.pack <$>) <$> G.list (R.linear 0 8) (G.list (R.linear 0 24) (G.word8 R.constantBounded))
     mconcat (asVector64s 1 [mconcat bss]) === mconcat (asVector64s 1 bss)
     True === True
@@ -30,3 +31,10 @@ spec = describe "HaskellWorks.Data.Vector.AsVector64sSpec" $ do
     let expected  = mconcat (asVector64s 1 bss)
     (reverse . dropWhile (== 0) . reverse) (DVS.toList actual) === (reverse . dropWhile (== 0) . reverse) (DVS.toList expected)
     True === True
+  it "Conversion of ByteString works 3" $ requireProperty $ do
+    bss <- forAll $ (BS.pack <$>) <$> G.list (R.linear 0 8) (G.list (R.linear 0 24) (G.word8 R.constantBounded))
+    let actual    = mconcat (asVector64s 1 bss)
+    let expected  = asVector64 (mconcat bss)
+    (reverse . dropWhile (== 0) . reverse) (DVS.toList actual) === (reverse . dropWhile (== 0) . reverse) (DVS.toList expected)
+    True === True
+


### PR DESCRIPTION
## Performance comparison
Before:
```
benchmarking medium.csv/Foldl' over Lazy ByteString via Vector Word64
time                 1.614 s    (727.1 ms .. 2.881 s)
                     0.936 R²   (0.849 R² .. 1.000 R²)
mean                 2.034 s    (1.786 s .. 2.444 s)
std dev              357.6 ms   (0.0 s .. 379.7 ms)
variance introduced by outliers: 47% (moderately inflated)
```
After:
```
benchmarking medium.csv/Foldl' over Lazy ByteString via Vector Word64
time                 739.9 ms   (697.3 ms .. 774.5 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 723.9 ms   (712.1 ms .. 731.9 ms)
std dev              12.04 ms   (0.0 s .. 13.89 ms)
variance introduced by outliers: 19% (moderately inflated)
```