### PR TITLE
New padded function

### DIFF
--- a/src/HaskellWorks/Data/Vector/Storable.hs
+++ b/src/HaskellWorks/Data/Vector/Storable.hs
@@ -2,23 +2,10 @@ module HaskellWorks.Data.Vector.Storable where
 
 import Data.Word
 
-import qualified Data.ByteString.Internal as BSI
-import qualified Data.Vector.Storable     as DVS
-import qualified Foreign.ForeignPtr       as F
-import qualified Foreign.Marshal.Unsafe   as F
-import qualified Foreign.Ptr              as F
+import qualified Data.Vector.Storable as DVS
 
 {-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
 
 padded :: Int -> DVS.Vector Word8 -> DVS.Vector Word8
-padded n v = F.unsafeLocalState $ do
-  let (srcFptr, srcOffset, srcLen) = DVS.unsafeToForeignPtr v
-  tgtFptr <- BSI.mallocByteString n
-  F.withForeignPtr srcFptr $ \srcPtr -> do
-    F.withForeignPtr tgtFptr $ \tgtPtr -> do
-      let dataLen = n `min` srcLen
-      let dataPtr = srcPtr `F.plusPtr` srcOffset
-      let padPtr = dataPtr `F.plusPtr` dataLen
-      BSI.memcpy tgtPtr dataPtr (n `min` srcLen)
-      _ <- BSI.memset padPtr 0 $ fromIntegral ((n - srcLen) `max` 0)
-      return $ DVS.unsafeFromForeignPtr tgtFptr 0 n
+padded n v = v <> DVS.replicate ((n - DVS.length v) `max` 0) 0
+{-# INLINE padded #-}

--- a/src/HaskellWorks/Data/Vector/Storable.hs
+++ b/src/HaskellWorks/Data/Vector/Storable.hs
@@ -1,0 +1,24 @@
+module HaskellWorks.Data.Vector.Storable where
+
+import Data.Word
+
+import qualified Data.ByteString.Internal as BSI
+import qualified Data.Vector.Storable     as DVS
+import qualified Foreign.ForeignPtr       as F
+import qualified Foreign.Marshal.Unsafe   as F
+import qualified Foreign.Ptr              as F
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+
+padded :: Int -> DVS.Vector Word8 -> DVS.Vector Word8
+padded n v = F.unsafeLocalState $ do
+  let (srcFptr, srcOffset, srcLen) = DVS.unsafeToForeignPtr v
+  tgtFptr <- BSI.mallocByteString n
+  F.withForeignPtr srcFptr $ \srcPtr -> do
+    F.withForeignPtr tgtFptr $ \tgtPtr -> do
+      let dataLen = n `min` srcLen
+      let dataPtr = srcPtr `F.plusPtr` srcOffset
+      let padPtr = dataPtr `F.plusPtr` dataLen
+      BSI.memcpy tgtPtr dataPtr (n `min` srcLen)
+      _ <- BSI.memset padPtr 0 $ fromIntegral ((n - srcLen) `max` 0)
+      return $ DVS.unsafeFromForeignPtr tgtFptr 0 n

--- a/src/HaskellWorks/Data/Vector/Storable.hs
+++ b/src/HaskellWorks/Data/Vector/Storable.hs
@@ -1,5 +1,6 @@
 module HaskellWorks.Data.Vector.Storable where
 
+import Data.Semigroup ((<>))
 import Data.Word
 
 import qualified Data.Vector.Storable as DVS


### PR DESCRIPTION
Hopefully the single occurrence of `GHC.Prim.newAlignedPinnedByteArray` means vector fusion was successful in optimising away my temporary vector allocation.

```
# Pastebin Hmg2HrbQ
d343a2a585ce2e9034197ca95f494da9
  $wpadded ::
    GHC.Prim.Int#
    -> GHC.Prim.Int#
    -> GHC.Prim.Addr#
    -> GHC.ForeignPtr.ForeignPtrContents
    -> Data.Vector.Storable.Vector GHC.Word.Word8
  {- Arity: 4, Strictness: <L,A><S,U><S,U><L,U>, Inline: [0],
     Unfolding: (\ (ww :: GHC.Prim.Int#)
                   (ww1 :: GHC.Prim.Int#)
                   (ww2 :: GHC.Prim.Addr#)
                   (ww3 :: GHC.ForeignPtr.ForeignPtrContents) ->
                 case GHC.Magic.runRW#
                        @ ('GHC.Types.TupleRep
                             '['GHC.Types.TupleRep '[], 'GHC.Types.LiftedRep])
                        @ (# GHC.Prim.State# GHC.Prim.RealWorld,
                             Data.Vector.Storable.Vector GHC.Word.Word8 #)
                        (\ (s1 :: GHC.Prim.State# GHC.Prim.RealWorld)[OneShot] ->
                         case GHC.Prim.<# ww1 0# of lwild1 {
                           DEFAULT
                           -> case GHC.Prim.<# ww1 0# of lwild {
                                DEFAULT
                                -> case GHC.Prim.newAlignedPinnedByteArray#
                                          @ GHC.Prim.RealWorld
                                          ww1
                                          1#
                                          s1 of ds { (#,#) ipv ipv1 ->
                                   let {
                                     ipv5 :: GHC.Prim.Addr#
                                     = GHC.Prim.byteArrayContents#
                                         ipv1
                                           `cast`
                                         (UnsafeCo representational (GHC.Prim.MutableByteArray#
                                                                       GHC.Prim.RealWorld) GHC.Prim.ByteArray#)
                                   } in
                                   let {
                                     ipv2 :: GHC.ForeignPtr.ForeignPtrContents
                                     = GHC.ForeignPtr.PlainPtr ipv1
                                   } in
                                   case {__pkg_ccall base-4.11.1.0 GHC.Prim.Addr#
                                                                   -> GHC.Prim.Addr#
                                                                   -> GHC.Prim.Word#
                                                                   -> GHC.Prim.State#
                                                                        GHC.Prim.RealWorld
                                                                   -> (# GHC.Prim.State#
                                                                           GHC.Prim.RealWorld,
                                                                         GHC.Prim.Addr# #)}
                                          ipv5
                                          ww2
                                          (GHC.Prim.int2Word# ww1)
                                          ipv of wild3 { (#,#) ds4 ds5 ->
                                   case GHC.Prim.touch#
                                          @ 'GHC.Types.LiftedRep
                                          @ GHC.ForeignPtr.ForeignPtrContents
                                          ww3
                                          ds4 of s' { DEFAULT ->
                                   case GHC.Prim.touch#
                                          @ 'GHC.Types.LiftedRep
                                          @ GHC.ForeignPtr.ForeignPtrContents
                                          ipv2
                                          s' of s'1 { DEFAULT ->
                                   (# s'1,
                                      Data.Vector.Storable.Vector
                                        @ GHC.Word.Word8
                                        ww1
                                        ipv5
                                        ipv2 #) } } } }
                                1#
                                -> case HaskellWorks.Data.Vector.Storable.padded1 ww1
                                   ret_ty (# GHC.Prim.State# GHC.Prim.RealWorld,
                                             Data.Vector.Storable.Vector GHC.Word.Word8 #)
                                   of {} }
                           1#
                           -> case Data.Vector.Fusion.Bundle.Size.$wlvl1 ww1
                              ret_ty (# GHC.Prim.State# GHC.Prim.RealWorld,
                                        Data.Vector.Storable.Vector GHC.Word.Word8 #)
                              of {} }) of ds1 { (#,#) ipv1 ipv2 ->
                 ipv2 }) -}
```