### PR TITLE
Benchmarking various implementations of mapAccumL

### DIFF
--- a/bench/Bench/MapAccumL.hs
+++ b/bench/Bench/MapAccumL.hs
@@ -1,0 +1,10 @@
+module Bench.MapAccumL where
+
+import Data.Word
+
+import qualified Data.Vector.Storable              as DVS
+import qualified HaskellWorks.Data.Vector.Storable as DVS
+
+mapAccumL :: DVS.Vector Word64 -> DVS.Vector Word64
+mapAccumL = snd . DVS.mapAccumL f 0
+  where f a b = (a + b, a * b)

--- a/bench/Bench/MapAccumLFusable.hs
+++ b/bench/Bench/MapAccumLFusable.hs
@@ -1,0 +1,10 @@
+module Bench.MapAccumLFusable where
+
+import Data.Word
+
+import qualified Data.Vector.Storable              as DVS
+import qualified HaskellWorks.Data.Vector.Storable as DVS
+
+mapAccumLFusable :: DVS.Vector Word64 -> DVS.Vector Word64
+mapAccumLFusable = snd . DVS.mapAccumLFusable f 0
+  where f a b = (a + b, a * b)

--- a/bench/Bench/MapId.hs
+++ b/bench/Bench/MapId.hs
@@ -1,0 +1,9 @@
+module Bench.MapId where
+
+import Data.Word
+
+import qualified Data.Vector.Storable as DVS
+
+mapId :: DVS.Vector Word64 -> DVS.Vector Word64
+mapId = DVS.map id
+{-# INLINE mapId #-}

--- a/bench/Bench/MapOnId.hs
+++ b/bench/Bench/MapOnId.hs
@@ -1,0 +1,12 @@
+module Bench.MapOnId where
+
+import Data.Vector.Fusion.Util (Id (..))
+import Data.Word
+
+import qualified Data.Vector.Storable as DVS
+
+mapOnId :: DVS.Vector Word64 -> DVS.Vector Word64
+mapOnId v = unId go
+  where go :: Id (DVS.Vector Word64)
+        go = DVS.mapM return v
+{-# INLINE mapOnId #-}

--- a/bench/Bench/MapOnStateId.hs
+++ b/bench/Bench/MapOnStateId.hs
@@ -1,0 +1,15 @@
+module Bench.MapOnStateId where
+
+import Control.Monad.Trans.State
+import Data.Vector.Fusion.Util   (Id (..))
+import Data.Word
+
+import qualified Data.Vector.Storable as DVS
+
+mapOnStateId :: DVS.Vector Word64 -> DVS.Vector Word64
+mapOnStateId v = unId go
+  where go :: Id (DVS.Vector Word64)
+        go = fst <$> runStateT ho 0
+        ho :: StateT Word64 Id (DVS.Vector Word64)
+        ho = DVS.mapM return v
+{-# INLINE mapOnStateId #-}

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -67,6 +67,7 @@ benchRankJson40Conduits =
     [ bench "mapAccumL               for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . snd . DVS.mapAccumL               (\a b -> (a + b, a * b)) 3 <$> us)) vs)
     , bench "mapAccumLViaStrictState for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . snd . DVS.mapAccumLViaStrictState (\a b -> (a + b, a * b)) 3 <$> us)) vs)
     , bench "mapAccumLViaLazyState   for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . snd . DVS.mapAccumLViaLazyState   (\a b -> (a + b, a * b)) 3 <$> us)) vs)
+    , bench "mapAccumLFusable        for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . snd . DVS.mapAccumLFusable        (\a b -> (a + b, a * b)) 3 <$> us)) vs)
     ]
   ]
 

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -69,6 +69,7 @@ benchRankJson40Conduits =
     , bench "mapAccumLViaStrictState for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . snd . DVS.mapAccumLViaStrictState (\a b -> (a + b, a * b)) 3 <$> us)) vs)
     , bench "mapAccumLViaLazyState   for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . snd . DVS.mapAccumLViaLazyState   (\a b -> (a + b, a * b)) 3 <$> us)) vs)
     , bench "mapAccumLFusable        for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . snd . DVS.mapAccumLFusable        (\a b -> (a + b, a * b)) 3 <$> us)) vs)
+    , bench "mapAccumLViaTranscribe  for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . snd . DVS.mapAccumLViaTranscribe  (\a b -> (a + b, a * b)) 3 <$> us)) vs)
     -- , bench "mapOnStateId            for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . B.mapOnStateId <$> us)) vs)
     -- , bench "mapOnId                 for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . B.mapOnId      <$> us)) vs)
     -- , bench "map                     for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . B.mapId        <$> us)) vs)

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -56,11 +56,16 @@ readLazyByteStringAsVectorList filePath = do
   return (asVector64 <$> LBS.toChunks lbs)
 
 mapOnStateId :: DVS.Vector Word64 -> DVS.Vector Word64
-mapOnStateId v = unId $ go
+mapOnStateId v = unId go
   where go :: Id (DVS.Vector Word64)
         go = fst <$> flip runStateT 0 ho
         ho :: StateT Word64 Id (DVS.Vector Word64)
         ho = DVS.mapM return v
+
+mapOnId :: DVS.Vector Word64 -> DVS.Vector Word64
+mapOnId v = unId go
+  where go :: Id (DVS.Vector Word64)
+        go = DVS.mapM return v
 
 benchRankJson40Conduits :: [Benchmark]
 benchRankJson40Conduits =
@@ -76,6 +81,8 @@ benchRankJson40Conduits =
     , bench "mapAccumLViaLazyState   for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . snd . DVS.mapAccumLViaLazyState   (\a b -> (a + b, a * b)) 3 <$> us)) vs)
     , bench "mapAccumLFusable        for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . snd . DVS.mapAccumLFusable        (\a b -> (a + b, a * b)) 3 <$> us)) vs)
     , bench "mapOnStateId            for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . mapOnStateId <$> us)) vs)
+    , bench "mapOnId                 for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . mapOnId      <$> us)) vs)
+    , bench "map                     for DVS.Vector Word64" (whnf (\us -> sum (DVS.length . DVS.map id   <$> us)) vs)
     ]
   ]
 

--- a/package.yaml
+++ b/package.yaml
@@ -18,6 +18,7 @@ dependencies:
 - base            >= 4.8        && < 5
 - bytestring      >= 0.9        && < 0.11
 - mmap            >= 0.5        && < 0.6
+- mtl             >= 2          && < 3
 - vector          >= 0.12       && < 0.13
 - semigroups      >= 0.8.4      && < 0.19
 - transformers    >= 0.4        && < 0.6

--- a/project.sh
+++ b/project.sh
@@ -6,25 +6,29 @@ STACK_FLAGS="
   --flag hw-rankselect:bmi2
 "
 
-case $1 in
+cmd="$1"
+shift
+
+case $cmd in
   build)
     stack build \
       --test --no-run-tests --bench --no-run-benchmarks \
-      $STACK_FLAGS
+      $STACK_FLAGS "$@"
     ;;
 
   test)
     stack test \
-      $STACK_FLAGS
+      $STACK_FLAGS "$@"
     ;;
 
   bench)
     stack bench \
-      $STACK_FLAGS
+      $STACK_FLAGS "$@"
     ;;
 
   repl)
     stack repl \
-      $STACK_FLAGS
+      $STACK_FLAGS "$@"
     ;;
 esac
+

--- a/src/HaskellWorks/Data/Vector/Storable.hs
+++ b/src/HaskellWorks/Data/Vector/Storable.hs
@@ -6,19 +6,29 @@ module HaskellWorks.Data.Vector.Storable
   , mapAccumL
   , mapAccumLViaLazyState
   , mapAccumLViaStrictState
+  , mapAccumLFusable
   ) where
 
-import Control.Monad.ST     (ST)
-import Data.Monoid          (Monoid (..), (<>))
+import Control.Monad
+import Control.Monad.ST          (ST)
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.State
+import Data.Monoid               (Monoid (..), (<>))
 import Data.Tuple
-import Data.Vector.Storable (Storable)
+import Data.Vector.Fusion.Bundle (Bundle, MBundle, inplace)
+import Data.Vector.Storable      (Storable)
 import Data.Word
-import Prelude              hiding (foldMap)
+import Prelude                   hiding (foldMap)
 
-import qualified Control.Monad.State.Lazy     as MSL
-import qualified Control.Monad.State.Strict   as MSS
-import qualified Data.Vector.Storable         as DVS
-import qualified Data.Vector.Storable.Mutable as DVSM
+import qualified Control.Monad.State.Lazy          as MSL
+import qualified Control.Monad.State.Strict        as MSS
+import qualified Data.Vector.Fusion.Bundle         as DVFB
+import qualified Data.Vector.Fusion.Bundle.Monadic as DVFBM
+import qualified Data.Vector.Fusion.Stream.Monadic as DVFSM
+import qualified Data.Vector.Fusion.Util           as DVFU
+import qualified Data.Vector.Generic               as DVG
+import qualified Data.Vector.Storable              as DVS
+import qualified Data.Vector.Storable.Mutable      as DVSM
 
 {-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
 
@@ -73,3 +83,45 @@ mapAccumLViaStrictState f a vb = swap . flip MSS.runState a $ DVS.forM vb go
           MSS.put a1
           return c1
 {-# INLINE mapAccumLViaStrictState #-}
+
+unstreamM :: (Storable a, Monad m) => MBundle m u a -> m (DVS.Vector a)
+{-# INLINE [1] unstreamM #-}
+unstreamM s = do
+  xs <- DVFBM.toList s
+  return $ DVG.unstream $ DVFB.unsafeFromList (DVFBM.size s) xs
+
+mapAccumLFusable :: forall a b c. (Storable b, Storable c)
+  => (a -> b -> (a, c))
+  -> a
+  -> DVS.Vector b
+  -> (a, DVS.Vector c)
+mapAccumLFusable f a v = swap $ DVFU.unId $ flip runStateT a $ unstreamM (bundleMapAccumL f a (DVG.stream v))
+{-# INLINE mapAccumLFusable #-}
+
+-- | Map a function over a 'Bundle'
+bundleMapAccumL :: Monad m => (a -> b -> (a, c)) -> a -> DVFBM.Bundle m v b -> DVFBM.Bundle (StateT a m) v c
+bundleMapAccumL f = bundleMapAccumLM (\a b -> return (f a b))
+{-# INLINE bundleMapAccumL #-}
+
+-- | Map a monadic function over a 'Bundle'
+bundleMapAccumLM :: Monad m => (a -> b -> m (a, c)) -> a -> DVFBM.Bundle m v b -> DVFBM.Bundle (StateT a m) v c
+bundleMapAccumLM f a DVFBM.Bundle{DVFBM.sElems = s, DVFBM.sSize = n} = DVFBM.fromStream (streamMapAccumLM f a s) n
+{-# INLINE_FUSED bundleMapAccumLM #-}
+
+streamMapAccumL :: Monad m => (a -> b -> (a, c)) -> a -> DVFSM.Stream m b -> DVFSM.Stream (StateT a m) c
+streamMapAccumL f = streamMapAccumLM (\a b -> return (f a b))
+{-# INLINE streamMapAccumL #-}
+
+streamMapAccumLM :: forall m a b c . Monad m => (a -> b -> m (a, c)) -> a -> DVFSM.Stream m b -> DVFSM.Stream (StateT a m) c
+streamMapAccumLM f a (DVFSM.Stream step t) = DVFSM.Stream (step' step) (a, t)
+  where step' :: forall s . (s -> m (DVFSM.Step s b)) -> (a, s) -> StateT a m (DVFSM.Step (a, s) c)
+        step' innerStep (a, s) = do
+          r <- lift $ innerStep s
+          case r of
+            DVFSM.Yield b s' -> do
+              (a', c') <- lift $ f a b
+              liftM  (`DVFSM.Yield` (a', s')) (return c')
+            DVFSM.Skip    s' -> return (DVFSM.Skip    (a, s'))
+            DVFSM.Done       -> put a >> return DVFSM.Done
+        {-# INLINE_INNER step' #-}
+{-# INLINE_FUSED streamMapAccumLM #-}

--- a/src/HaskellWorks/Data/Vector/Storable.hs
+++ b/src/HaskellWorks/Data/Vector/Storable.hs
@@ -4,14 +4,19 @@ module HaskellWorks.Data.Vector.Storable
   ( padded
   , foldMap
   , mapAccumL
+  , mapAccumLViaLazyState
+  , mapAccumLViaStrictState
   ) where
 
 import Control.Monad.ST     (ST)
 import Data.Monoid          (Monoid (..), (<>))
+import Data.Tuple
 import Data.Vector.Storable (Storable)
 import Data.Word
 import Prelude              hiding (foldMap)
 
+import qualified Control.Monad.State.Lazy     as MSL
+import qualified Control.Monad.State.Strict   as MSS
 import qualified Data.Vector.Storable         as DVS
 import qualified Data.Vector.Storable.Mutable as DVSM
 
@@ -42,3 +47,29 @@ mapAccumL f a vb = DVS.createT $ do
             go (i + 1) a1 vc
           else return a0
 {-# INLINE mapAccumL #-}
+
+mapAccumLViaLazyState :: forall a b c. (Storable b, Storable c)
+  => (a -> b -> (a, c))
+  -> a
+  -> DVS.Vector b
+  -> (a, DVS.Vector c)
+mapAccumLViaLazyState f a vb = swap . flip MSL.runState a $ DVS.forM vb go
+  where go b = do
+          a0 <- MSL.get
+          let (a1, c1) = f a0 b
+          MSL.put a1
+          return c1
+{-# INLINE mapAccumLViaLazyState #-}
+
+mapAccumLViaStrictState :: forall a b c. (Storable b, Storable c)
+  => (a -> b -> (a, c))
+  -> a
+  -> DVS.Vector b
+  -> (a, DVS.Vector c)
+mapAccumLViaStrictState f a vb = swap . flip MSS.runState a $ DVS.forM vb go
+  where go b = do
+          a0 <- MSS.get
+          let (a1, c1) = f a0 b
+          MSS.put a1
+          return c1
+{-# INLINE mapAccumLViaStrictState #-}

--- a/test/HaskellWorks/Data/Vector/StorableSpec.hs
+++ b/test/HaskellWorks/Data/Vector/StorableSpec.hs
@@ -58,3 +58,17 @@ spec = describe "HaskellWorks.Data.Vector.StorableSpec" $ do
     let actual    = DVS.toList <$> DVS.mapAccumLViaLazyState f (1 :: Int) (DVS.fromList as)
     let expected  = L.mapAccumL f (1 :: Int) as
     actual === expected
+
+  it "mapAccumLFusable: f a b = (a + 1, b * 2)" $ requireProperty $ do
+    as <- forAll $ G.list (R.linear 0 10) (G.word64 (R.linear 0 255))
+    let f a b = (a + 1, b * 2)
+    let actual    = DVS.toList <$> DVS.mapAccumLFusable f (1 :: Int) (DVS.fromList as)
+    let expected  = L.mapAccumL f (1 :: Int) as
+    actual === expected
+  it "mapAccumLFusable: f a b = (a * 2, b + 1)" $ requireProperty $ do
+    as <- forAll $ G.list (R.linear 0 10) (G.word64 (R.linear 0 255))
+    let f a b = (a * 2, b + 1)
+    let actual    = DVS.toList <$> DVS.mapAccumLViaLazyState f (1 :: Int) (DVS.fromList as)
+    let expected  = L.mapAccumL f (1 :: Int) as
+    actual === expected
+

--- a/test/HaskellWorks/Data/Vector/StorableSpec.hs
+++ b/test/HaskellWorks/Data/Vector/StorableSpec.hs
@@ -23,8 +23,38 @@ spec = describe "HaskellWorks.Data.Vector.StorableSpec" $ do
   it "mapAccumL: f a b = (a + 1, b * 2)" $ requireProperty $ do
     as <- forAll $ G.list (R.linear 0 10) (G.word64 (R.linear 0 255))
     let f a b = (a + 1, b * 2)
-    (DVS.toList <$> DVS.mapAccumL f (0 :: Int) (DVS.fromList as)) === L.mapAccumL f (0 :: Int) as
+    let actual    = DVS.toList <$> DVS.mapAccumL f (0 :: Int) (DVS.fromList as)
+    let expected  = L.mapAccumL f (0 :: Int) as
+    actual === expected
   it "mapAccumL: f a b = (a * 2, b + 1)" $ requireProperty $ do
     as <- forAll $ G.list (R.linear 0 10) (G.word64 (R.linear 0 255))
     let f a b = (a * 2, b + 1)
-    (DVS.toList <$> DVS.mapAccumL f (0 :: Int) (DVS.fromList as)) === L.mapAccumL f (0 :: Int) as
+    let actual    = DVS.toList <$> DVS.mapAccumL f (0 :: Int) (DVS.fromList as)
+    let expected  = L.mapAccumL f (0 :: Int) as
+    actual === expected
+
+  it "mapAccumLViaStrictState: f a b = (a + 1, b * 2)" $ requireProperty $ do
+    as <- forAll $ G.list (R.linear 0 10) (G.word64 (R.linear 0 255))
+    let f a b = (a + 1, b * 2)
+    let actual    = DVS.toList <$> DVS.mapAccumLViaStrictState f (1 :: Int) (DVS.fromList as)
+    let expected  = L.mapAccumL f (1 :: Int) as
+    actual === expected
+  it "mapAccumLViaStrictState: f a b = (a * 2, b + 1)" $ requireProperty $ do
+    as <- forAll $ G.list (R.linear 0 10) (G.word64 (R.linear 0 255))
+    let f a b = (a * 2, b + 1)
+    let actual    = DVS.toList <$> DVS.mapAccumLViaStrictState f (1 :: Int) (DVS.fromList as)
+    let expected  = L.mapAccumL f (1 :: Int) as
+    actual === expected
+
+  it "mapAccumLViaLazyState: f a b = (a + 1, b * 2)" $ requireProperty $ do
+    as <- forAll $ G.list (R.linear 0 10) (G.word64 (R.linear 0 255))
+    let f a b = (a + 1, b * 2)
+    let actual    = DVS.toList <$> DVS.mapAccumLViaLazyState f (1 :: Int) (DVS.fromList as)
+    let expected  = L.mapAccumL f (1 :: Int) as
+    actual === expected
+  it "mapAccumLViaLazyState: f a b = (a * 2, b + 1)" $ requireProperty $ do
+    as <- forAll $ G.list (R.linear 0 10) (G.word64 (R.linear 0 255))
+    let f a b = (a * 2, b + 1)
+    let actual    = DVS.toList <$> DVS.mapAccumLViaLazyState f (1 :: Int) (DVS.fromList as)
+    let expected  = L.mapAccumL f (1 :: Int) as
+    actual === expected


### PR DESCRIPTION
```
benchmarking medium.csv/mapAccumL               for DVS.Vector Word64
time                 47.15 ms   (46.05 ms .. 47.96 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 49.41 ms   (48.25 ms .. 52.10 ms)
std dev              3.158 ms   (1.723 ms .. 5.072 ms)
variance introduced by outliers: 22% (moderately inflated)

benchmarking medium.csv/mapAccumLViaStrictState for DVS.Vector Word64
time                 758.9 ms   (727.6 ms .. 800.3 ms)
                     1.000 R²   (0.999 R² .. NaN R²)
mean                 758.6 ms   (750.8 ms .. 762.9 ms)
std dev              7.599 ms   (3.272 ms .. 9.896 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking medium.csv/mapAccumLViaLazyState   for DVS.Vector Word64
time                 98.42 ms   (97.20 ms .. 99.55 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 99.56 ms   (99.05 ms .. 100.2 ms)
std dev              933.5 μs   (668.8 μs .. 1.246 ms)
```